### PR TITLE
ctags option for ycm_collect_identifiers_from_tags_files

### DIFF
--- a/common/.vimrc
+++ b/common/.vimrc
@@ -241,8 +241,8 @@ if executable("ag")
   let g:ctrlp_user_command = 'ag %s -l --nocolor -g ""'
 endif
 
-" reload ctags
-nnoremap <leader>C :!ctags -R --exclude=.git --exclude=log --exclude=tmp *<CR><CR>
+" reload ctags, --fields=+l needs by YCM
+nnoremap <leader>C :!ctags -R --fields=+l --exclude=.git --exclude=log --exclude=tmp *<CR><CR>
 
 " git and ack stuff
 let g:gitgutter_enabled = 1


### PR DESCRIPTION
YCM doc for [g:ycm_collect_identifiers_from_tags_files](https://github.com/Valloric/YouCompleteMe#the-gycm_collect_identifiers_from_tags_files-option) says:

The only supported tag format is the [Exuberant Ctags format](http://ctags.sourceforge.net/FORMAT). The
format from "plain" ctags is NOT supported. Ctags needs to be called with the
`--fields=+l` option (that's a lowercase `L`, not a one) because YCM needs the
`language:<lang>` field in the tags output.
