### PR TITLE
Local configuration adaption to ensure consisten <C-j> mapping in vim

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -467,6 +467,9 @@ endif
 " make C-a, C-x work properly
 set nrformats=
 
+" make C-j work consistent in C programms
+let g:C_Ctrl_j='off'
+
 " potential lag fix
 let g:matchparen_insert_timeout=1
 

--- a/ubuntu/vim_install.sh
+++ b/ubuntu/vim_install.sh
@@ -38,3 +38,10 @@ sudo apt install nodejs npm -y
 cd ~/.vim/bundle/tern_for_vim/
 npm install
 sudo npm install -g jshint
+
+#remove confilct with autocomplete in c.vim bundle
+cd ~/.vim/bundle/c.vim/ftplugin/
+sed -i -e '/if !exists("g:C_Ctrl_j")/,+4d' c.vim
+git add c.vim 
+git commit -m 'Disable local C_Ctrl_j for autocomplete compatibiliy.'
+cd

--- a/ubuntu/vim_install.sh
+++ b/ubuntu/vim_install.sh
@@ -38,10 +38,3 @@ sudo apt install nodejs npm -y
 cd ~/.vim/bundle/tern_for_vim/
 npm install
 sudo npm install -g jshint
-
-#remove confilct with autocomplete in c.vim bundle
-cd ~/.vim/bundle/c.vim/ftplugin/
-sed -i -e '/if !exists("g:C_Ctrl_j")/,+4d' c.vim
-git add c.vim 
-git commit -m 'Disable local C_Ctrl_j for autocomplete compatibiliy.'
-cd


### PR DESCRIPTION
This solves the issue on my system with Ubuntu. (Please double check.)
I am not sure how this fits best for macOS or arch, but adaption should be easy.